### PR TITLE
Replace donation widget with donation link.

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,6 +33,8 @@ def get_twitch_stream(user):
 
 
 def build_streamer_json(user, stream, participant_id):
+    donate_url = 'http://www.extra-life.org/index.cfm?fuseaction=donorDrive.' \
+                 'participant&participantID={}'.format(participant_id)
     s = {
         'username': user,
         'playing': 'Offline',
@@ -40,6 +42,7 @@ def build_streamer_json(user, stream, participant_id):
         'url': '#',
         'preview': 'http://placehold.it/640x360',
         'participant_id': participant_id,
+        'donate': donate_url if participant_id else None,
         'fps': 0,
         'views': 0
     }

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,43 +32,34 @@
   {% for s in streams %}
     <div class="container">
       <div class="row"> 
-        <div class="col-md-4">
+        <div class="col-md-6">
           <div class="embed-responsive embed-responsive-16by9">
             <!--<img class="img-responsive" src="{{ s.preview }}"/>-->
             <iframe class="embed-responsive-item"
-                src="http://player.twitch.tv/?channel={{ s.username }}" 
-                height="360" 
-                width="640" 
-                frameborder="0" 
+                src="http://player.twitch.tv/?channel={{ s.username }}"
+                height="360"
+                width="640"
+                frameborder="0"
                 scrolling="no"
                 allowfullscreen="true">
             </iframe>
           </div>
         </div>
-        <div class="col-md-4">
+        <div class="col-md-6">
           <h1 class="title">{{ s.username }}</h1>
           <h4><span class="light-key">Playing:</span> {{ s.playing }}</h4>
           <h4><span class="light-key">Viewers:</span> {{ s.viewers }}</h4>
           <p class="light-text">
             <div class="row">
               <div class="col-md-3"><i class="glyphicon glyphicon-film"></i> {{ s.fps | round(2) }}</div>
-              <div class="col-md-3"><i class="glyphicon glyphicon-eye-open"></i> {{ s.views }}</div>
+              <div class="col-md-9"><i class="glyphicon glyphicon-eye-open"></i> {{ s.views }}</div>
             </div>
           </p>
           <a class="light-key" href="{{ s.url }}" target="_blank">Watch on Twitch</a>
+          {% if s.participant_id %}
+          &nbsp;|&nbsp; <a class="light-key" href="{{ s.donate }}" target="_blank">Donate</a>
+          {% endif %}
         </div>
-        {% if s.participant_id %}
-        <div class="col-md-4">
-          <iframe
-            src="http://www.extra-life.org/index.cfm?fuseaction=widgets.300x250thermo&participantID={{ s.participant_id }}"
-            width="302"
-            height="252"
-            frameborder="0"
-            scrolling="no">
-              <a href="http://www.extra-life.org/index.cfm?fuseaction=donorDrive.participant&participantID={{ s.participant_id }}">Make a Donation!</a>
-          </iframe>
-        </div>
-        {% endif %}
       </div>
     </div>
   {% endfor %}


### PR DESCRIPTION
The Extra Life donation widget was sized and styled in a way that did not quite fit
our template aesthetically - Replace the widget with a link to the users
donation page. If the user does not have a participant ID, simply ignore
the donation link.
